### PR TITLE
Add turn on/off feature

### DIFF
--- a/custom_components/smartir/climate.py
+++ b/custom_components/smartir/climate.py
@@ -48,7 +48,7 @@ CONF_HUMIDITY_SENSOR = "humidity_sensor"
 CONF_POWER_SENSOR = "power_sensor"
 CONF_POWER_SENSOR_RESTORE_STATE = "power_sensor_restore_state"
 
-SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE
+SUPPORT_FLAGS = ClimateEntityFeature.TARGET_TEMPERATURE | ClimateEntityFeature.FAN_MODE | ClimateEntityFeature.TURN_OFF | ClimateEntityFeature.TURN_ON
 
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {


### PR DESCRIPTION
Add ClimateEntityFeature.TURN_OFF and ClimateEntityFeature.TURN_ON to support calling the turn_on and turn_off services.
It is required now for climate entity:
https://developers.home-assistant.io/blog/2024/01/24/climate-climateentityfeatures-expanded?_highlight=climateentityfeature

And will be required in 6 months for fan entity. I didn't added it in this PR to maintain compatibility with < 2024.8 but must be updated soon:
https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off?_highlight=fanentityfeature
